### PR TITLE
Several changes handle files across several PAKs. More details below.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "MetroidPrimeRemasterModelDumper/ImageLibrary"]
+	path = MetroidPrimeRemasterModelDumper/ImageLibrary
+	url = https://github.com/KillzXGaming/ImageLibrary

--- a/MetroidPrimeRemasterModelDumper/FileData/BufferHelper.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/BufferHelper.cs
@@ -47,6 +47,9 @@ namespace DKCTF
         {
             var vertices = new CMDL.CVertex[vertexInfo.VertexCount];
 
+            uint texCoord0Offset = 0;
+
+
             foreach (var comp in vertexInfo.Components)
             {
                 Console.WriteLine($"comp {comp.Type} {comp.Format}");
@@ -54,39 +57,35 @@ namespace DKCTF
                 var buffer = buffers[startIndex + (int)comp.BufferID];
                 using (var reader = new FileReader(buffer))
                 {
+                    uint trueOffset = comp.Offset;
+
                     reader.SetByteOrder(!isLittleEndian); //switch is little endianness
-
-                    
-                    if(comp.Type == CMDL.EVertexComponent.in_texCoord1)
-                    {
-                        comp.Offset += 4;
-                    }
-                    if (comp.Type == CMDL.EVertexComponent.in_texCoord2)
-                    {
-                        comp.Offset += 8;
-                    }
-                    if (comp.Type == CMDL.EVertexComponent.in_texCoord3)
-                    {
-                        comp.Offset += 12;
-                    }
-
                     Console.WriteLine("Offset: " + comp.Offset);
-
+                    Console.WriteLine("Buffer Size: " + buffer.Length.ToString());
+                    // Attempt to fix the UV reader
+                    if (comp.Type == CMDL.EVertexComponent.in_texCoord1)
+                    {
+                        if(comp.Format == CMDL.VertexFormat.Format_16_16_16_HalfSingle)
+                        {
+                            if (comp.Offset == texCoord0Offset)
+                            {
+                                trueOffset += 4;
+                            }
+                            
+                            else if (comp.Offset == texCoord0Offset + 8)
+                            {
+                                trueOffset -= 4;
+                            }
+                            
+                        }
+                    }
 
                     for (int i = 0; i < vertexInfo.VertexCount; i++)
                     {
                         if (vertices[i] == null) vertices[i] = new CMDL.CVertex();
 
                         CMDL.CVertex vertex = vertices[i];
-
-                        try
-                        {
-                            reader.SeekBegin(comp.Offset + i * comp.Stride);
-                        }
-                        catch
-                        {
-                            break;
-                        }
+                        reader.SeekBegin(trueOffset + i * comp.Stride);
 
                         switch (comp.Type)
                         {
@@ -98,38 +97,34 @@ namespace DKCTF
                                 break;
                             case CMDL.EVertexComponent.in_texCoord0:
                                 vertex.TexCoord0 = ReadData(reader, comp.Format).Xy();
+                                texCoord0Offset = comp.Offset;
                                 break;
 
                             case CMDL.EVertexComponent.in_texCoord1:
+                                vertex.hasTexCoord1 = true;
                                 try
                                 {
                                     vertex.TexCoord1 = ReadData(reader, comp.Format).Xy();
-                                    break;
                                 }
                                 catch
                                 {
-                                    break;
+                                    Console.WriteLine("Bad Tex Coord 1 data. Use Tex Coord 0.");
+                                    reader.SeekBegin((comp.Offset) + i * comp.Stride);
+                                    vertex.TexCoord1 = ReadData(reader, comp.Format).Xy();
+                                    //throw;
                                 }
+                                break;
+
                             case CMDL.EVertexComponent.in_texCoord2:
-                                try
-                                {
-                                    vertex.TexCoord2 = ReadData(reader, comp.Format).Xy();
-                                    break;
-                                }
-                                catch
-                                {
-                                    break;
-                                }
+                                vertex.hasTexCoord2 = true;
+                                vertex.TexCoord2 = ReadData(reader, comp.Format).Xy();
+                                break;
+
                             case CMDL.EVertexComponent.in_texCoord3:
-                                try
-                                {
-                                    vertex.TexCoord3 = ReadData(reader, comp.Format).Xy();
-                                    break;
-                                }
-                                catch
-                                {
-                                    break;
-                                }
+                                vertex.hasTexCoord3 = true;
+                                vertex.TexCoord3 = ReadData(reader, comp.Format).Xy();
+                                break;
+
                             case CMDL.EVertexComponent.in_boneWeights:
                                 vertex.BoneWeights = ReadData(reader, comp.Format);
                                 break;

--- a/MetroidPrimeRemasterModelDumper/FileData/BufferHelper.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/BufferHelper.cs
@@ -43,12 +43,13 @@ namespace DKCTF
         /// <summary>
         /// Gets a vertex list from the provided buffer and descriptor info.
         /// </summary>
+        
         public static CMDL.CVertex[] LoadVertexBuffer(List<byte[]> buffers, int startIndex, CMDL.VertexBuffer vertexInfo, bool isLittleEndian, bool swapTexCoord)
         {
             var vertices = new CMDL.CVertex[vertexInfo.VertexCount];
 
-            uint texCoord0Offset = 0;
-
+            // Track how many bytes have been consumed at a specific offset to handle aliasing
+            Dictionary<uint, uint> consumedBytesAtOffset = new Dictionary<uint, uint>();
 
             foreach (var comp in vertexInfo.Components)
             {
@@ -57,27 +58,17 @@ namespace DKCTF
                 var buffer = buffers[startIndex + (int)comp.BufferID];
                 using (var reader = new FileReader(buffer))
                 {
+                    reader.SetByteOrder(!isLittleEndian); //switch is little endianness
                     uint trueOffset = comp.Offset;
 
-                    reader.SetByteOrder(!isLittleEndian); //switch is little endianness
-                    Console.WriteLine("Offset: " + comp.Offset);
-                    Console.WriteLine("Buffer Size: " + buffer.Length.ToString());
-                    // Attempt to fix the UV reader
-                    if (comp.Type == CMDL.EVertexComponent.in_texCoord1)
+                    // If an offset is shared (aliased), advance the true offset by the bytes already consumed
+                    if (consumedBytesAtOffset.ContainsKey(comp.Offset))
                     {
-                        if(comp.Format == CMDL.VertexFormat.Format_16_16_16_HalfSingle)
-                        {
-                            if (comp.Offset == texCoord0Offset)
-                            {
-                                trueOffset += 4;
-                            }
-                            
-                            else if (comp.Offset == texCoord0Offset + 8)
-                            {
-                                trueOffset -= 4;
-                            }
-                            
-                        }
+                        trueOffset += consumedBytesAtOffset[comp.Offset];
+                    }
+                    else
+                    {
+                        consumedBytesAtOffset[comp.Offset] = 0;
                     }
 
                     for (int i = 0; i < vertexInfo.VertexCount; i++)
@@ -87,55 +78,44 @@ namespace DKCTF
                         CMDL.CVertex vertex = vertices[i];
                         reader.SeekBegin(trueOffset + i * comp.Stride);
 
+                        Vector4 rawData = ReadData(reader, comp.Format);
+
                         switch (comp.Type)
                         {
                             case CMDL.EVertexComponent.in_position:
-                                vertex.Position = ReadData(reader, comp.Format).Xyz();
+                                vertex.Position = rawData.Xyz();
                                 break;
                             case CMDL.EVertexComponent.in_normal:
-                                vertex.Normal = ReadData(reader, comp.Format).Xyz();
+                                vertex.Normal = rawData.Xyz();
                                 break;
                             case CMDL.EVertexComponent.in_texCoord0:
-                                vertex.TexCoord0 = ReadData(reader, comp.Format).Xy();
-                                texCoord0Offset = comp.Offset;
-                                break;
+                                vertex.TexCoord0 = rawData.Xy();
+                                //Console.WriteLine("Made it here");
 
+                                // Check if the format is wide enough to contain a second packed UV map
+                                if (comp.Format == CMDL.VertexFormat.Format_16_16_16_HalfSingle ||
+                                    comp.Format == CMDL.VertexFormat.Format_32_32_32_32_Single)
+                                {
+                                    //Console.WriteLine("Also made it here");
+                                    vertex.hasTexCoord1 = true;
+                                    vertex.TexCoord1 = new Vector2(rawData.Z, rawData.W);
+                                }
+                                break;
                             case CMDL.EVertexComponent.in_texCoord1:
-                                vertex.hasTexCoord1 = true;
-                                try
-                                {
-                                    vertex.TexCoord1 = ReadData(reader, comp.Format).Xy();
-                                }
-                                catch
-                                {
-                                    Console.WriteLine("Bad Tex Coord 1 data. Use Tex Coord 0.");
-                                    reader.SeekBegin((comp.Offset) + i * comp.Stride);
-                                    vertex.TexCoord1 = ReadData(reader, comp.Format).Xy();
-                                    //throw;
-                                }
-                                break;
-
-                            case CMDL.EVertexComponent.in_texCoord2:
                                 vertex.hasTexCoord2 = true;
-                                vertex.TexCoord2 = ReadData(reader, comp.Format).Xy();
+                                vertex.TexCoord2 = rawData.Xy();
                                 break;
-
-                            case CMDL.EVertexComponent.in_texCoord3:
-                                vertex.hasTexCoord3 = true;
-                                vertex.TexCoord3 = ReadData(reader, comp.Format).Xy();
-                                break;
-
                             case CMDL.EVertexComponent.in_boneWeights:
-                                vertex.BoneWeights = ReadData(reader, comp.Format);
+                                vertex.BoneWeights = rawData;
                                 break;
                             case CMDL.EVertexComponent.in_boneIndices:
-                                vertex.BoneIndices = ReadData(reader, comp.Format);
+                                vertex.BoneIndices = rawData;
                                 break;
                             case CMDL.EVertexComponent.in_color:
-                                vertex.Color1 = ReadData(reader, comp.Format);
+                                vertex.Color1 = rawData;
                                 break;
                             case CMDL.EVertexComponent.in_tangent0:
-                                vertex.Tangent = ReadData(reader, comp.Format);
+                                vertex.Tangent = rawData;
                                 break;
                         }
                     }

--- a/MetroidPrimeRemasterModelDumper/FileData/BufferHelper.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/BufferHelper.cs
@@ -56,13 +56,38 @@ namespace DKCTF
                 {
                     reader.SetByteOrder(!isLittleEndian); //switch is little endianness
 
+                    
+                    if(comp.Type == CMDL.EVertexComponent.in_texCoord1)
+                    {
+                        comp.Offset += 4;
+                    }
+                    if (comp.Type == CMDL.EVertexComponent.in_texCoord2)
+                    {
+                        comp.Offset += 8;
+                    }
+                    if (comp.Type == CMDL.EVertexComponent.in_texCoord3)
+                    {
+                        comp.Offset += 12;
+                    }
+
+                    Console.WriteLine("Offset: " + comp.Offset);
+
+
                     for (int i = 0; i < vertexInfo.VertexCount; i++)
                     {
                         if (vertices[i] == null) vertices[i] = new CMDL.CVertex();
 
                         CMDL.CVertex vertex = vertices[i];
 
-                        reader.SeekBegin(comp.Offset + i * comp.Stride);
+                        try
+                        {
+                            reader.SeekBegin(comp.Offset + i * comp.Stride);
+                        }
+                        catch
+                        {
+                            break;
+                        }
+
                         switch (comp.Type)
                         {
                             case CMDL.EVertexComponent.in_position:
@@ -74,15 +99,37 @@ namespace DKCTF
                             case CMDL.EVertexComponent.in_texCoord0:
                                 vertex.TexCoord0 = ReadData(reader, comp.Format).Xy();
                                 break;
+
                             case CMDL.EVertexComponent.in_texCoord1:
-                                if (swapTexCoord)
-                                    vertex.TexCoord0 = ReadData(reader, comp.Format).Xy();
-                                else
+                                try
+                                {
                                     vertex.TexCoord1 = ReadData(reader, comp.Format).Xy();
-                                break;
+                                    break;
+                                }
+                                catch
+                                {
+                                    break;
+                                }
                             case CMDL.EVertexComponent.in_texCoord2:
-                                vertex.TexCoord2 = ReadData(reader, comp.Format).Xy();
-                                break;
+                                try
+                                {
+                                    vertex.TexCoord2 = ReadData(reader, comp.Format).Xy();
+                                    break;
+                                }
+                                catch
+                                {
+                                    break;
+                                }
+                            case CMDL.EVertexComponent.in_texCoord3:
+                                try
+                                {
+                                    vertex.TexCoord3 = ReadData(reader, comp.Format).Xy();
+                                    break;
+                                }
+                                catch
+                                {
+                                    break;
+                                }
                             case CMDL.EVertexComponent.in_boneWeights:
                                 vertex.BoneWeights = ReadData(reader, comp.Format);
                                 break;
@@ -90,7 +137,7 @@ namespace DKCTF
                                 vertex.BoneIndices = ReadData(reader, comp.Format);
                                 break;
                             case CMDL.EVertexComponent.in_color:
-                                vertex.Color = ReadData(reader, comp.Format);
+                                vertex.Color1 = ReadData(reader, comp.Format);
                                 break;
                             case CMDL.EVertexComponent.in_tangent0:
                                 vertex.Tangent = ReadData(reader, comp.Format);
@@ -112,6 +159,10 @@ namespace DKCTF
                 case CMDL.VertexFormat.Format_16_16_16_HalfSingle:  return new Vector4(
                      (float)reader.ReadHalf(), (float)reader.ReadHalf(),
                      (float)reader.ReadHalf(), (float)reader.ReadHalf());
+                case CMDL.VertexFormat.Format_8_8_8_8_UNorm:
+                    return new Vector4(
+                       (float)reader.ReadByte() / 255, (float)reader.ReadByte() / 255,
+                       (float)reader.ReadByte() / 255, (float)reader.ReadByte() / 255);
                 case CMDL.VertexFormat.Format_8_8_8_8_Uint:
                     return new Vector4(
                        reader.ReadByte(), reader.ReadByte(),

--- a/MetroidPrimeRemasterModelDumper/FileData/CHPR.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/CHPR.cs
@@ -1,7 +1,10 @@
 ﻿using AvaloniaToolbox.Core.IO;
 using DKCTF;
+using System;
 using System.Numerics;
 using System.Reflection.Metadata.Ecma335;
+using System.Xml.Linq;
+using static RetroStudioPlugin.Files.FileData.CHPR;
 using static RetroStudioPlugin.Files.FileData.CHPR.SBaseInfo;
 
 namespace RetroStudioPlugin.Files.FileData
@@ -146,6 +149,8 @@ namespace RetroStudioPlugin.Files.FileData
                     this.SkinnedBones.Add(boneName);
                 }
 
+                //string boneIDContents = "Bone Building Information: ";
+
                 for (int i = 0; i < renderContext.InverseMatrices.Length; i++)
                 {
                     // Bone ID
@@ -172,6 +177,7 @@ namespace RetroStudioPlugin.Files.FileData
                         LocalTransform = worldSpace, // Adjusted afterward
                     });
                 }
+
 
                 for (int i = 0; i < Bones.Count; i++)
                 {
@@ -250,6 +256,7 @@ namespace RetroStudioPlugin.Files.FileData
             {
                 return (int)(NodeIDs[index] & 0xFFFF);
             }
+
         }
 
         public class SAnimContext
@@ -282,24 +289,35 @@ namespace RetroStudioPlugin.Files.FileData
         {
             public SNodeSet NodeSet;
 
+            public byte[] section1;
+            public byte[] section2;
+            public byte[] section3;
+            public byte[] section4;
+
             public (ushort, ushort)[] Section5;
+
+            public byte num1;
+            public ushort num2;
+            public ushort num3;
+            public ushort num4;
+            public ushort num5;
 
             public SAbsContext(FileReader reader)
             {
                 /* SAbsContext::Load  */
 
-                byte num1 = reader.ReadByte();
-                ushort num2 = reader.ReadUInt16();
-                ushort num3 = reader.ReadUInt16();
-                ushort num4 = reader.ReadUInt16();
-                ushort num5 = reader.ReadUInt16();
+                num1 = reader.ReadByte();
+                num2 = reader.ReadUInt16();
+                num3 = reader.ReadUInt16();
+                num4 = reader.ReadUInt16();
+                num5 = reader.ReadUInt16();
 
                 /* SAbsContext::ReadIntoMemory */
 
-                byte[] section1 = reader.ReadBytes(num1 * 6);
-                byte[] section2 = reader.ReadBytes(num3);
-                byte[] section3 = reader.ReadBytes(num4);
-                byte[] section4 = reader.ReadBytes(num5);
+                section1 = reader.ReadBytes(num1 * 6);
+                section2 = reader.ReadBytes(num3);
+                section3 = reader.ReadBytes(num4);
+                section4 = reader.ReadBytes(num5);
 
                 NodeSet = new SNodeSet(reader);
 
@@ -313,28 +331,38 @@ namespace RetroStudioPlugin.Files.FileData
 
         public class SRenderContext
         {
-            public Matrix4x4[] InverseMatrices;
+            public Matrix4x4[] InverseMatrices; // DO NOT USE
             public Matrix4x4[] SkinnedInverseMatrices;
 
             public ushort[] SkinnedMatrixBoneIDs;
-            public ushort[] InverseMatrixBoneIds;
+            public ushort[] InverseMatrixBoneIds; // DO NOT USE
+
+            public ushort[] section2;
+            public ushort[] section3;
+            public byte[] section4;
+
+            public ushort num1;
+            public ushort num2;
+            public ushort num3;
+            public ushort num4;
+            public uint num5;
 
             public SRenderContext(FileReader reader)
             {
-                ushort num1 = reader.ReadUInt16();
-                ushort num2 = reader.ReadUInt16();
-                ushort num3 = reader.ReadUInt16();
-                ushort num4 = reader.ReadUInt16();
-                uint num5 = reader.ReadUInt32();
+                num1 = reader.ReadUInt16();
+                num2 = reader.ReadUInt16();
+                num3 = reader.ReadUInt16();
+                num4 = reader.ReadUInt16();
+                num5 = reader.ReadUInt32();
 
                 SkinnedMatrixBoneIDs = reader.ReadUInt16s((int)num1);
-                ushort[] section2 = reader.ReadUInt16s((int)num2);
-                ushort[] section3 = reader.ReadUInt16s((int)num3);
+                section2 = reader.ReadUInt16s((int)num2);
+                section3 = reader.ReadUInt16s((int)num3);
                 InverseMatrixBoneIds = reader.ReadUInt16s((int)num4);
 
                 SkinnedInverseMatrices = reader.ReadMatrix3x4s(num1 + 1);
                 InverseMatrices = reader.ReadMatrix3x4s(num4);
-                byte[] section4 = reader.ReadBytes((int)num5);
+                section4 = reader.ReadBytes((int)num5);
             }
         }
 

--- a/MetroidPrimeRemasterModelDumper/FileData/CHPR.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/CHPR.cs
@@ -49,7 +49,6 @@ namespace RetroStudioPlugin.Files.FileData
             public List<SModelNode> ModelNodes = new List<SModelNode>();
             public SSubCharData SubCharData;
 
-
             public CharacterInfo(FileReader reader)
             {
                 // Name pool

--- a/MetroidPrimeRemasterModelDumper/FileData/CMDL.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/CMDL.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+#nullable disable
 
 namespace DKCTF
 {
@@ -14,6 +15,8 @@ namespace DKCTF
     /// </summary>
     public class CMDL : FileForm
     {
+        public SModelHeader Header;
+
         /// <summary>
         /// The meshes of the model used to display the model.
         /// </summary>
@@ -27,12 +30,15 @@ namespace DKCTF
         /// <summary>
         /// The vertex buffer list to read the buffer attributes.
         /// </summary>
-        List<VertexBuffer> VertexBuffers = new List<VertexBuffer>();
+        public List<VertexBuffer> VertexBuffers = new List<VertexBuffer>();
 
         /// <summary>
         /// The index buffer list to read the index buffer data.
         /// </summary>
         List<CGraphicsIndexBufferToken> IndexBuffer = new List<CGraphicsIndexBufferToken>();
+
+        public List<byte[]> VertexBytes = new List<byte[]>();
+        public List<byte[]> IndexBytes = new List<byte[]>();
 
         /// <summary>
         /// Determines which variant of the file to parse. Switch reads strings and materials differently.
@@ -46,7 +52,7 @@ namespace DKCTF
         /// <summary>
         /// The meta data header for parsing gpu buffers and decompressing.
         /// </summary>
-        SMetaData Meta;
+        public SMetaData Meta;
 
         public CMDL() { }
 
@@ -85,7 +91,7 @@ namespace DKCTF
                     reader.ReadUInt32(); //unk
                     break;
                 case "HEAD":
-                    reader.ReadStruct<SModelHeader>();
+                    Header = reader.ReadStruct<SModelHeader>();
                     break;
                 case "MTRL":
                     if (IsSwitch)
@@ -115,8 +121,10 @@ namespace DKCTF
 
                         //Decompress
                         var data = IOFileExtension.DecompressedBuffer(reader, buffer.CompressedSize, buffer.DecompressedSize, IsSwitch);
-                      //  if (buffer.DecompressedSize != data.Length)
-                      //      throw new Exception();
+                        //  if (buffer.DecompressedSize != data.Length)
+                        //      throw new Exception();
+
+                        IndexBytes.Add(data);
 
                         //All indices
                         var indices = BufferHelper.LoadIndexBuffer(data, this.IndexBuffer[i].IndexType, IsSwitch);
@@ -147,11 +155,12 @@ namespace DKCTF
                         if (buffer.DecompressedSize != data.Length)
                             throw new Exception();
 
+                        VertexBytes.Add(data);
+
                         vertexData.Add(data);
 
                         startPos += buffer.CompressedSize;
                     }
-
 
                     for (int j = 0; j < VertexBuffers.Count; j++)
                     {
@@ -195,19 +204,23 @@ namespace DKCTF
                     switch (dformat)
                     {
                         case 0: //Texture
-                            material.Textures.Add(dtype, reader.ReadStruct<CMaterialTextureTokenData>());
+                            material.Textures.Add(reader.ReadStruct<CMaterialTextureTokenData>());
                             break;
                         case 1: //Color
+                            //material.Colors.Add(reader.ReadStruct<Color4f>());
                             material.Colors.Add(dtype, reader.ReadStruct<Color4f>());
                             break;
                         case 2: //Scaler
+                            //material.Scalars.Add(reader.ReadSingle());
                             material.Scalars.Add(dtype, reader.ReadSingle());
                             break;
                         case 3: //int
+                            //material.Int.Add(reader.ReadInt32());
                             material.Int.Add(dtype, reader.ReadInt32());
                             break;
                         case 4: //CLayeredTextureData
                             {
+                                
                                 reader.ReadUInt32();
                                 reader.ReadSingles(4); //color
                                 reader.ReadSingles(4); //color
@@ -222,9 +235,11 @@ namespace DKCTF
                                 var texture3 = reader.ReadStruct<CObjectId>();
                                 if (!texture3.IsZero())
                                     reader.ReadStruct<STextureUsageInfo>();
+                                
                             }
                             break;
                         case 5: //int4
+                            //material.Int4.Add(reader.ReadInt32s(4));
                             material.Int4.Add(dtype, reader.ReadInt32s(4));
                             break;
                         default:
@@ -287,18 +302,22 @@ namespace DKCTF
                     switch (dformat)
                     {
                         case "TXTR": //Texture
-                            material.Textures.Add(dtype, reader.ReadStruct<CMaterialTextureTokenData>());
+                            material.Textures.Add(reader.ReadStruct<CMaterialTextureTokenData>());
                             break;
                         case "COLR": //Color
+                            //material.Colors.Add(reader.ReadStruct<Color4f>());
                             material.Colors.Add(dtype, reader.ReadStruct<Color4f>());
                             break;
                         case "SCLR": //Scaler
+                            //material.Scalars.Add(reader.ReadSingle());
                             material.Scalars.Add(dtype, reader.ReadSingle());
                             break;
                         case "INT ": //int
+                            //material.Int.Add(reader.ReadInt32());
                             material.Int.Add(dtype, reader.ReadInt32());
                             break;
                         case "INT4": //int4
+                            //material.Int4.Add(reader.ReadInt32s(4));
                             material.Int4.Add(dtype, reader.ReadInt32s(4));
                             break;
                         case "CPLX": //CLayeredTextureData
@@ -308,18 +327,40 @@ namespace DKCTF
                                 reader.ReadSingles(4); //color
                                 reader.ReadSingles(4); //color
                                 reader.ReadByte(); //Flags
+
                                 var texture1 = reader.ReadStruct<CObjectId>();
                                 if (!texture1.IsZero())
-                                    reader.ReadStruct<STextureUsageInfo>();
+                                {
+                                    var info1 = reader.ReadStruct<STextureUsageInfo>();
+                                    CMaterialTextureTokenData TextureData1 = new CMaterialTextureTokenData();
+                                    TextureData1.FileID = texture1;
+                                    TextureData1.UsageInfo = info1;
+                                    material.Textures.Add(TextureData1);
+                                }
+
                                 var texture2 = reader.ReadStruct<CObjectId>();
                                 if (!texture2.IsZero())
-                                    reader.ReadStruct<STextureUsageInfo>();
+                                {
+                                    var info2 = reader.ReadStruct<STextureUsageInfo>();
+                                    CMaterialTextureTokenData TextureData2 = new CMaterialTextureTokenData();
+                                    TextureData2.FileID = texture2;
+                                    TextureData2.UsageInfo = info2;
+                                    material.Textures.Add(TextureData2);
+                                }
+
                                 var texture3 = reader.ReadStruct<CObjectId>();
                                 if (!texture3.IsZero())
-                                    reader.ReadStruct<STextureUsageInfo>();
+                                {
+                                    var info3 = reader.ReadStruct<STextureUsageInfo>();
+                                    CMaterialTextureTokenData TextureData3 = new CMaterialTextureTokenData();
+                                    TextureData3.FileID = texture3;
+                                    TextureData3.UsageInfo = info3;
+                                    material.Textures.Add(TextureData3);
+                                }
                             }
                             break;
                         case "MA4": //Matrix4x4
+                            //material.Matrices.Add(reader.ReadSingles(16));
                             material.Matrices.Add(dtype, reader.ReadSingles(16));
                             break;
                         default:
@@ -409,11 +450,12 @@ namespace DKCTF
             public Vector2 TexCoord0;
             public Vector2 TexCoord1;
             public Vector2 TexCoord2;
+            public Vector2 TexCoord3;
 
             public Vector4 BoneWeights = new Vector4(1, 0, 0, 0);
             public Vector4 BoneIndices = new Vector4(0);
 
-            public Vector4 Color = Vector4.One;
+            public Vector4 Color1 = Vector4.One;
 
             public Vector4 Tangent;
         }
@@ -427,7 +469,16 @@ namespace DKCTF
 
             public uint Flags { get; set; }
 
-            public Dictionary<string, CMaterialTextureTokenData> Textures = new Dictionary<string, CMaterialTextureTokenData>();
+            public List<CMaterialTextureTokenData> Textures = new List<CMaterialTextureTokenData>();
+
+            //public List<float> Scalars = new List<float>();
+            //public List<int> Int = new List<int>();
+            //public List<int[]> Int4 = new List<int[]>();
+            //public List<float[]> Matrices = new List<float[]>();
+
+            //public List<Color4f> Colors = new List<Color4f>();
+
+            //public Dictionary<string, CMaterialTextureTokenData> Textures = new Dictionary<string, CMaterialTextureTokenData>();
 
             public Dictionary<string, float> Scalars = new Dictionary<string, float>();
             public Dictionary<string, int> Int = new Dictionary<string, int>();
@@ -534,40 +585,48 @@ namespace DKCTF
 
         public enum VertexFormat
         {
-            Byte = 0,
-            Format_16_16_HalfSingle = 20,
-            Format_8_8_8_8_Uint = 22,
-            Format_16_16_16_HalfSingle = 34,
-            Format_32_32_32_Single = 37,
-            Format_32_32_32_32_Single = 40,
+            Byte = 0, // Unsigned Byte 5121 SCALAR
+            Format_16_16_HalfSingle = 20, // Float 5126 VEC2
+            Format_8_8_8_8_UNorm = 21, // Float 5126 VEC2
+            Format_8_8_8_8_Uint = 22, // Unsigned Byte 5121 VEC4
+            Format_16_16_16_HalfSingle = 34, // Float 5126 VEC3
+            Format_32_32_32_Single = 37, // Float 5126 VEC3
+            Format_32_32_32_32_Single = 40, // Float 5126 VEC4
         }
 
         public enum EVertexComponent
         {
-            in_position,
-            in_normal,
-            in_tangent0,
-            in_tangent1,
-            in_texCoord0,
-            in_texCoord1,
-            in_texCoord2,
-            in_texCoord3,
+            in_position = 0,
+            in_normal = 1,
+            in_tangent0 = 2,
+            in_tangent1 = 3,
+            in_tangent2 = 4,
+            in_texCoord0 = 5,
+            in_texCoord1 = 6,
+            in_texCoord2 = 7,
+            in_texCoord3 = 8,
             in_color = 9,
             in_boneIndices = 10,
             in_boneWeights = 11,
-            in_bakedLightingCoord,
-            in_bakedLightingTangent,
-            in_vertInstanceColor,
-            //3x4 matrices
-            in_vertTransform0,
-            in_vertTransform1,
-            in_vertTransform2,
-            //3x4 matrices for instancing
-            in_vertTransformIT0,
-            in_vertTransformIT1,
-            in_vertTransformIT2,
-            in_lastPosition,
-            in_currentPosition,
+            in_bakedLightingCoord = 12,
+            in_bakedLightingTangent = 13,
+            in_vertInstanceParams = 14,
+            in_vertInstanceColor = 15,
+            in_vertTransform0 = 16,
+            in_vertTransform1 = 17,
+            in_vertTransform2 = 18,
+            in_currentPosition = 19,
+            in_VertInstanceOpacityParams = 20,
+            in_VertInstanceColorIndexingParams = 21,
+            in_VertInstanceOpacityIndexingParams = 22,
+            in_VertInstancePaintParams = 23,
+            in_BakedLightingLookup = 24,
+            in_MaterialChoice0 = 25,
+            in_MaterialChoice1 = 26,
+            in_MaterialChoice2 = 27,
+            in_MaterialChoice3 = 28,
+
+
         }
 
         //Meta data from PAK archive

--- a/MetroidPrimeRemasterModelDumper/FileData/CMDL.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/CMDL.cs
@@ -1,11 +1,14 @@
 ﻿using AvaloniaToolbox.Core.IO;
+using EvilWithin2Tool;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using static AvaloniaToolbox.Core.ConsoleLogger;
 #nullable disable
 
 namespace DKCTF
@@ -21,6 +24,8 @@ namespace DKCTF
         /// The meshes of the model used to display the model.
         /// </summary>
         public List<CMesh> Meshes = new List<CMesh>();
+
+        public List<ModelLOD> ParsedLODs = new List<ModelLOD>();
 
         /// <summary>
         /// The materials of the model for rendering the mesh.
@@ -48,6 +53,17 @@ namespace DKCTF
                          this.FileHeader.FormType == "WMDL" && this.FileHeader.VersionA >= 0x36;
 
         public bool IsR11 = true;
+
+        public byte[] unk1;
+        public byte[] unk2;
+        public uint shortCount;
+        public ushort[] shorts;
+        public byte lodCount;
+        public LODinfo[] lods;
+        public uint hasLODRule;
+        public LodRule[] LodRules;
+
+
 
         /// <summary>
         /// The meta data header for parsing gpu buffers and decompressing.
@@ -123,6 +139,7 @@ namespace DKCTF
                         var data = IOFileExtension.DecompressedBuffer(reader, buffer.CompressedSize, buffer.DecompressedSize, IsSwitch);
                         //  if (buffer.DecompressedSize != data.Length)
                         //      throw new Exception();
+
 
                         IndexBytes.Add(data);
 
@@ -407,7 +424,115 @@ namespace DKCTF
                     Header = mesh,
                 });
             }
+
+            this.unk1 = new byte[(numMeshes + 3) / 4];
+            this.unk2 = new byte[(numMeshes + 7) / 8];
+            for (int i = 0; i < unk1.Length; i++)
+            {
+                this.unk1[i] = reader.ReadByte();
+            }
+            for (int i = 0; i < unk2.Length; i++)
+            {
+                this.unk2[i] = reader.ReadByte();
+            }
+
+            this.shortCount = reader.ReadUInt32();
+            this.shorts = new ushort[this.shortCount];
+
+            for (int i = 0; i < shortCount; i++)
+            {
+                this.shorts[i] = reader.ReadUInt16();
+            }
+
+            this.lodCount = reader.ReadByte();
+            this.lods = new LODinfo[lodCount];
+
+            for (int i = 0; i < lodCount; i++)
+            {
+                //Console.WriteLine("LOD outer: " + i);
+                LODinfo info = new LODinfo();
+
+                info.ReadInner(reader);
+
+                this.lods[i] = info;
+            }
+
+            this.hasLODRule = reader.ReadUInt32();
+
+            // Conditionally read the LOD rules if the flag is set to 1
+            if (this.hasLODRule == 1)
+            {
+                this.LodRules = new LodRule[this.lodCount];
+                for (int i = 0; i < this.lodCount; i++)
+                {
+                    this.LodRules[i] = new LodRule
+                    {
+                        Value = reader.ReadSingle() // SRenderModelLODRule is just a standard f32
+                    };
+                }
+            }
+            else
+            {
+                // Initialize empty to avoid null reference exceptions down the line
+                this.LodRules = new LodRule[0];
+            }
+
+            // Map meshes to their respective LOD buckets
+            for (int lodIndex = 0; lodIndex < this.lodCount; lodIndex++)
+            {
+                LODinfo currentLOD = this.lods[lodIndex];
+                ModelLOD parsedLOD = new ModelLOD();
+
+                if (this.hasLODRule == 1 && lodIndex < this.LodRules.Length)
+                {
+                    parsedLOD.Distance = this.LodRules[lodIndex].Value;
+                }
+
+                foreach (LODInner inner in currentLOD.inner)
+                {
+                    for (uint i = 0; i < inner.count; i++)
+                    {
+                        int meshIndex = this.shorts[inner.offset + i];
+
+                        // Add the index to our LOD bucket if it isn't there already
+                        if (!parsedLOD.MeshIndices.Contains(meshIndex))
+                        {
+                            parsedLOD.MeshIndices.Add(meshIndex);
+                        }
+
+                        // Keep your original tagging, it's still useful!
+                        if (meshIndex < this.Meshes.Count)
+                        {
+                            this.Meshes[meshIndex].LODs.Add(lodIndex);
+                        }
+                    }
+                }
+
+                this.ParsedLODs.Add(parsedLOD);
+            }
+
             Console.WriteLine();
+        }
+
+        /// <summary>
+        /// Extracts only the meshes associated with LOD 0.
+        /// </summary>
+        public List<CMesh> GetHighestLODMeshes()
+        {
+            if (this.ParsedLODs.Count == 0) return new List<CMesh>();
+
+            List<CMesh> highLodMeshes = new List<CMesh>();
+
+            // ParsedLODs[0] contains the indices for the highest level of detail
+            foreach (int index in this.ParsedLODs[0].MeshIndices)
+            {
+                if (index < this.Meshes.Count)
+                {
+                    highLodMeshes.Add(this.Meshes[index]);
+                }
+            }
+
+            return highLodMeshes;
         }
 
         private void ReadVertexBuffer(FileReader reader)
@@ -457,6 +582,10 @@ namespace DKCTF
 
             public Vector4 Color1 = Vector4.One;
 
+            public bool hasTexCoord1 = false;
+            public bool hasTexCoord2 = false;
+            public bool hasTexCoord3 = false;
+
             public Vector4 Tangent;
         }
 
@@ -491,11 +620,16 @@ namespace DKCTF
         public class CMesh
         {
             public CRenderMesh Header;
-
             public List<CVertex> Vertices = new List<CVertex>();
-
             public uint[] Indices = new uint[0];
 
+            public HashSet<int> LODs = new HashSet<int>();
+
+            public bool hasTexCoord1 = false;
+            public bool hasTexCoord2 = false;
+            public bool hasTexCoord3 = false;
+
+            /*
             public void SetupVertices(List<CVertex> vertices)
             {
                 //Here we optmize the vertices to only use the vertices used by the mesh rather than use one giant list
@@ -506,14 +640,78 @@ namespace DKCTF
                     remappedIndices.Add((uint)vertexList.Count);
                     vertexList.Add(vertices[(int)Indices[i]]);
                 }
+
+                if (vertexList[0].hasTexCoord1)
+                {
+                    hasTexCoord1 = true;
+                }
+                if (vertexList[0].hasTexCoord2)
+                {
+                    hasTexCoord2 = true;
+                }
+                if (vertexList[0].hasTexCoord3)
+                {
+                    hasTexCoord3 = true;
+                }
+
+                this.Vertices = vertexList;
+                this.Indices = remappedIndices.ToArray();
+            }
+            */
+
+            public void SetupVertices(List<CVertex> vertices)
+            {
+                if (Indices.Length == 0) return;
+
+                // 1. Find the absolute minimum and maximum indices used by this mesh
+                uint minIndex = uint.MaxValue;
+                uint maxIndex = uint.MinValue;
+
+                for (int i = 0; i < Indices.Length; i++)
+                {
+                    if (Indices[i] < minIndex) minIndex = Indices[i];
+                    if (Indices[i] > maxIndex) maxIndex = Indices[i];
+                }
+
+                // 2. Slice out only the continuous range of vertices this mesh needs
+                List<CVertex> vertexList = new List<CVertex>();
+                int vertexCount = (int)(maxIndex - minIndex + 1);
+
+                for (int i = 0; i < vertexCount; i++)
+                {
+                    vertexList.Add(vertices[(int)(minIndex + i)]);
+                }
+
+                // 3. Remap the index buffer by subtracting the minimum index
+                // This preserves vertex sharing perfectly.
+                List<uint> remappedIndices = new List<uint>();
+                for (int i = 0; i < Indices.Length; i++)
+                {
+                    remappedIndices.Add(Indices[i] - minIndex);
+                }
+
+                // Assign texture coordinate flags safely
+                if (vertexList.Count > 0)
+                {
+                    hasTexCoord1 = vertexList[0].hasTexCoord1;
+                    hasTexCoord2 = vertexList[0].hasTexCoord2;
+                    hasTexCoord3 = vertexList[0].hasTexCoord3;
+                }
+
                 this.Vertices = vertexList;
                 this.Indices = remappedIndices.ToArray();
             }
         }
 
+        public class ModelLOD
+        {
+            public List<int> MeshIndices = new List<int>();
+            public float Distance;
+        }
+
         public class SSkinnedModelHeader : CChunkDescriptor
         {
-            public uint Unknown;
+            public uint unknown;
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
@@ -625,8 +823,6 @@ namespace DKCTF
             in_MaterialChoice1 = 26,
             in_MaterialChoice2 = 27,
             in_MaterialChoice3 = 28,
-
-
         }
 
         //Meta data from PAK archive
@@ -655,5 +851,36 @@ namespace DKCTF
             public uint CompressedSize;
             public uint DecompressedSize;
         }
+
+        // LOD stuff
+        public class LODinfo
+        {
+            public LODInner[] inner = new LODInner[5];
+
+            public void ReadInner(FileReader reader)
+            {
+                for (int i = 0; i < inner.Length; i++)
+                {
+                    LODInner tempinner = new LODInner();
+
+                    tempinner.offset = reader.ReadUInt32();
+                    tempinner.count = reader.ReadUInt32();
+
+                    inner[i] = tempinner;
+                }
+            }
+        }
+
+        public class LODInner
+        {
+            public uint offset;
+            public uint count;
+        }
+
+        public class LodRule
+        {
+            public float Value;
+        }
+
     }
 }

--- a/MetroidPrimeRemasterModelDumper/FileData/ModelManifester.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/ModelManifester.cs
@@ -53,11 +53,12 @@ namespace MetroidPrimeRemasterModelDumper
                         entry.SMDLFiles.Add(fileInfo.AssetEntry.FileID);
                     }
                     /*
-                    if (fileInfo.AssetEntry.Type == "CMDL")
+                    if (fileInfo.AssetEntry.Type == "WMDL")
                     {
-                        entry.CMDLFiles.Add(fileInfo.AssetEntry.FileID);
+                        entry.SMDLFiles.Add(fileInfo.AssetEntry.FileID);
                     }
                     */
+                    
                 }
 
                 PakManifestEntry.Add(entry);

--- a/MetroidPrimeRemasterModelDumper/FileData/ModelManifester.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/ModelManifester.cs
@@ -1,0 +1,163 @@
+﻿using DKCTF;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace MetroidPrimeRemasterModelDumper
+{
+    public static class ModelManifester
+    {
+        static List<FileInfo> RomFiles = new List<FileInfo>();
+        static List<MaterialManifestEntry> PakManifestEntry = new List<MaterialManifestEntry>();
+
+        public static void ProcessModels(string romDir)
+        {
+            DirectoryInfo DirInfo = new DirectoryInfo(@romDir);
+
+            foreach (var subdir in DirInfo.GetDirectories())
+            {
+                ScanForSubdir(subdir);
+            }
+
+            foreach (var file in DirInfo.GetFiles())
+            {
+                ScanForFile(DirInfo);
+            }
+
+            foreach (var file in RomFiles)
+            {
+                string pakFile = file.FullName;
+                Console.WriteLine(file.Name);
+                var ctx = new AvaloniaToolbox.Core.FileContext()
+                {
+                    FilePath = pakFile,
+                    FileName = Path.GetFileName(pakFile),
+                    Stream = File.OpenRead(pakFile),
+                };
+
+                PAK pak = new PAK() { FileInfo = ctx };
+                pak.Load(ctx);
+
+                MaterialManifestEntry entry = new MaterialManifestEntry();
+                entry.PakName = ctx.FileName;
+                entry.PakPath = ctx.FilePath;
+
+                foreach (var fileInfo in pak.files)
+                {
+                    if (fileInfo.AssetEntry.Type == "SMDL")
+                    {
+                        entry.SMDLFiles.Add(fileInfo.AssetEntry.FileID);
+                    }
+                    /*
+                    if (fileInfo.AssetEntry.Type == "CMDL")
+                    {
+                        entry.CMDLFiles.Add(fileInfo.AssetEntry.FileID);
+                    }
+                    */
+                }
+
+                PakManifestEntry.Add(entry);
+            }
+
+            List<MaterialManifestSerializableEntry> SerialEntry = new List<MaterialManifestSerializableEntry>();
+
+            foreach (var entry in PakManifestEntry)
+            {
+                List<string> smdl = new List<string>();
+                /*
+                List<string> cmdl = new List<string>();
+
+                foreach (var cmdlEntry in entry.CMDLFiles)
+                {
+                    if (cmdlEntry.ToString() == "516a2dbd-2baf-41d6-a79a-77861dafb705")
+                    {
+                        Console.WriteLine("In theory, the missing model should be here?");
+                    }
+                    cmdl.Add(cmdlEntry.ToString());
+                }
+                */
+
+                foreach (var smdlEntry in entry.SMDLFiles)
+                {
+                    smdl.Add(smdlEntry.ToString());
+                }
+
+                var newEntry = new MaterialManifestSerializableEntry
+                {
+                    PakName = entry.PakName,
+                    PakPath = entry.PakPath,
+                    SMDLFiles = smdl,
+                    //CMDLFiles = cmdl
+                };
+
+                SerialEntry.Add(newEntry);          
+            }
+
+            string jsonOutput = JsonSerializer.Serialize(SerialEntry, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            System.IO.File.WriteAllText(AppContext.BaseDirectory + "/ModelManifest.json", jsonOutput);
+
+        }
+
+        static void ScanForSubdir(DirectoryInfo subdir)
+        {
+            DirectoryInfo[] subdirs = subdir.GetDirectories();
+
+            if (subdirs.Length > 0)
+            {
+                //int i = 0;
+                foreach (var subsubdir in subdir.GetDirectories())
+                {
+                    ScanForSubdir(subsubdir);
+                }
+
+                ScanForFile(subdir);
+            }
+            else
+            {
+                ScanForFile(subdir);
+            }
+        }
+
+        static void ScanForFile(DirectoryInfo DirInfo)
+        {
+            foreach (var file in DirInfo.GetFiles())
+            {
+                if (file.Extension == ".pak")
+                {
+                    RomFiles.Add(file);
+                }
+
+            }
+        }
+    }
+
+    public class MaterialManifestEntry()
+    {
+        public string PakName = "";
+        public string PakPath = "";
+        public List<CObjectId> SMDLFiles = new List<CObjectId>();
+        //public List<CObjectId> CMDLFiles = new List<CObjectId>();
+    }
+
+    public class MaterialManifestSerializableEntry()
+    {
+        [JsonPropertyName("PakName")]
+        public string PakName { get; set; }
+        [JsonPropertyName("PakPath")]
+        public string PakPath { get; set; }
+
+        [JsonPropertyName("SMDLFiles")]
+        public List<string> SMDLFiles { get; set; }
+
+        //[JsonPropertyName("CMDLFiles")]
+        //public List<string> CMDLFiles { get; set; }
+    }
+}

--- a/MetroidPrimeRemasterModelDumper/FileData/SKEL.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/SKEL.cs
@@ -1,11 +1,6 @@
 ﻿using AvaloniaToolbox.Core.IO;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+#nullable disable
 
 namespace DKCTF
 {
@@ -106,7 +101,7 @@ namespace DKCTF
             {
                 var rot = reader.ReadQuaternion();
                 JointCoords.Add(new BoneCoord()
-                {   
+                {
                     Rotation = new Quaternion(rot.Y, rot.Z, rot.W, rot.X),
                     Scale = reader.ReadVector3(),
                     Position = reader.ReadVector3(),

--- a/MetroidPrimeRemasterModelDumper/FileData/TXTR.cs
+++ b/MetroidPrimeRemasterModelDumper/FileData/TXTR.cs
@@ -1,4 +1,5 @@
 ﻿using AvaloniaToolbox.Core.IO;
+using ImageLibrary;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -222,5 +223,102 @@ namespace DKCTF
             public uint CompressedSize;
             public uint Offset;
         }
+
+        public static Dictionary<uint, TextureFormat> FormatList = new()
+        {
+            {  0, TextureFormat.R8_UNORM },
+            {  1, TextureFormat.R8_SNORM },
+            {  2, TextureFormat.R8_UINT },
+            {  3, TextureFormat.R8_SINT },
+            {  4, TextureFormat.R16_UNORM },
+            {  5, TextureFormat.R16_SNORM },
+            {  6, TextureFormat.R16_UINT },
+            {  7, TextureFormat.R16_SINT },
+            {  8, TextureFormat.R16_FLOAT },
+            {  9, TextureFormat.R32_UINT },
+            {  10, TextureFormat.R32_SINT },
+
+            {  11, TextureFormat.R32_FLOAT },
+
+            {  12, TextureFormat.RGBA8_UNORM },
+            {  13, TextureFormat.RGBA8_SRGB },
+            {  14, TextureFormat.RGBA16_FLOAT },
+            {  15, TextureFormat.RGBA32_FLOAT },
+            {  16, TextureFormat.D16_UNORM },
+            {  17, TextureFormat.D16_UNORM },
+            {  18, TextureFormat.D24_UNORM_S8_UINT },
+            {  19, TextureFormat.D32_FLOAT },
+            {  20, TextureFormat.BC1_UNORM },
+            {  21, TextureFormat.BC1_SRGB },
+            {  22, TextureFormat.BC2_UNORM },
+            {  23, TextureFormat.BC2_SRGB },
+            {  24, TextureFormat.BC3_UNORM },
+            {  25, TextureFormat.BC3_SRGB },
+            {  26, TextureFormat.BC4_UNORM },
+            {  27, TextureFormat.BC4_SNORM },
+            {  28, TextureFormat.BC5_UNORM },
+            {  29, TextureFormat.BC5_SNORM },
+            {  30, TextureFormat.RG11B10_FLOAT },
+            {  31, TextureFormat.R32_FLOAT },
+
+            {  32, TextureFormat.RG8_UNORM },
+            {  33, TextureFormat.RG8_SNORM },
+            {  34, TextureFormat.RG8_UINT },
+            {  35, TextureFormat.RG8_SINT },
+
+            {  36, TextureFormat.RG16_FLOAT },
+            {  37, TextureFormat.RG16_UNORM },
+            {  38, TextureFormat.RG16_SNORM },
+            {  39, TextureFormat.RG16_UINT },
+            {  40, TextureFormat.RG16_SINT },
+
+            {  41, TextureFormat.RGBB10A2_UNORM },
+            {  42, TextureFormat.RGB10A2_UINT },
+            {  43, TextureFormat.RG32_UINT },
+            {  44, TextureFormat.RG32_SINT },
+            {  45, TextureFormat.RG32_FLOAT },
+            {  46, TextureFormat.RGBA16_UNORM },
+            {  47, TextureFormat.RGBA16_SNORM },
+            {  48, TextureFormat.RGBA16_UINT },
+            {  49, TextureFormat.RGBA16_SINT },
+            {  50, TextureFormat.RGBA32_UINT },
+            {  51, TextureFormat.RGBA32_SINT },
+            {  52, TextureFormat.RGBA8_UNORM }, // None
+            {  53, TextureFormat.ASTC_4x4_UNORM },
+            {  54, TextureFormat.ASTC_5x4_UNORM },
+            {  55, TextureFormat.ASTC_5x5_UNORM },
+            {  56, TextureFormat.ASTC_6x5_UNORM },
+            {  57, TextureFormat.ASTC_6x6_UNORM },
+            {  58, TextureFormat.ASTC_8x5_UNORM },
+            {  59, TextureFormat.ASTC_8x6_UNORM },
+            {  60, TextureFormat.ASTC_8x8_UNORM },
+            {  61, TextureFormat.ASTC_10x5_UNORM },
+            {  62, TextureFormat.ASTC_10x6_UNORM},
+            {  63, TextureFormat.ASTC_10x8_UNORM},
+            {  64, TextureFormat.ASTC_10x10_UNORM},
+            {  65, TextureFormat.ASTC_12x10_UNORM},
+            {  66, TextureFormat.ASTC_12x12_UNORM},
+
+            {  67, TextureFormat.ASTC_4x4_SRGB},
+            {  68, TextureFormat.ASTC_5x4_SRGB },
+            {  69, TextureFormat.ASTC_5x5_SRGB },
+            {  70, TextureFormat.ASTC_6x5_SRGB },
+            {  71, TextureFormat.ASTC_6x6_SRGB },
+            {  72, TextureFormat.ASTC_8x5_SRGB },
+            {  73, TextureFormat.ASTC_8x6_SRGB },
+            {  74, TextureFormat.ASTC_8x8_SRGB},
+            {  75, TextureFormat.ASTC_10x5_SRGB },
+            {  76, TextureFormat.ASTC_10x6_SRGB},
+            {  77, TextureFormat.ASTC_10x8_SRGB},
+            {  78, TextureFormat.ASTC_10x10_SRGB},
+            {  79, TextureFormat.ASTC_12x10_SRGB},
+            {  80, TextureFormat.ASTC_12x12_SRGB},
+
+            {  81, TextureFormat.BC6H_UF16 },
+            {  82, TextureFormat.BC6H_SF16 },
+            {  83, TextureFormat.BC7_UNORM },
+            {  84, TextureFormat.BC7_SRGB },
+        };
+
     }
 }

--- a/MetroidPrimeRemasterModelDumper/MetroidPrimeRemasterModelDumper.csproj
+++ b/MetroidPrimeRemasterModelDumper/MetroidPrimeRemasterModelDumper.csproj
@@ -5,14 +5,18 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BCnEncoder.Net" Version="2.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="AvaloniaToolbox.Core">
       <HintPath>Lib\AvaloniaToolbox.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="ImageLibrary">
-      <HintPath>Lib\ImageLibrary.dll</HintPath>
     </Reference>
     <Reference Include="IONET">
       <HintPath>..\src\AvaloniaToolbox\Lib\IONET.dll</HintPath>

--- a/MetroidPrimeRemasterModelDumper/Plugins/PAK.cs
+++ b/MetroidPrimeRemasterModelDumper/Plugins/PAK.cs
@@ -77,18 +77,34 @@ namespace DKCTF
                     file.MetaPointer = pack.MetaDataOffset + pack.MetaOffsets[pack.Assets[i].FileID.ToString()];
                 files.Add(file);
 
-                switch (file.AssetEntry.Type)
+                
+
+                try
                 {
-                    case "SMDL": ModelFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
-                    case "TXTR": TextureFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
-                    case "SKEL": SkeletonFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
-                    case "ANIM": AnimFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
-                  /*  case "CHAR":
-                        var c = new CHAR(file.FileData);
-                        file.FileName = $"Characters/{c.Name}/{c.Name}.char";
-                        CharFiles.Add(file.AssetEntry.FileID.ToString(), c);
-                        break;*/
+                    switch (file.AssetEntry.Type)
+                    {
+                        case "SMDL": ModelFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
+                        case "TXTR": TextureFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
+                        case "SKEL": SkeletonFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
+                        case "ANIM": AnimFiles.Add(file.AssetEntry.FileID.ToString(), file); break;
+                    }
                 }
+                catch
+                {
+                    continue;
+                }
+
+                /*
+                try
+                {
+                    
+                }
+                catch
+                {
+                    continue;
+                }
+                */
+                
             }
 
             foreach (var c in CharFiles)

--- a/MetroidPrimeRemasterModelDumper/Plugins/PAK.cs
+++ b/MetroidPrimeRemasterModelDumper/Plugins/PAK.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using System.IO;
 using AvaloniaToolbox.Core;
 using AvaloniaToolbox.Core.IO;
-using ImageLibrary;
+using ImageLibrary.Utils;
 
 namespace DKCTF
 {

--- a/MetroidPrimeRemasterModelDumper/Program.cs
+++ b/MetroidPrimeRemasterModelDumper/Program.cs
@@ -1,5 +1,16 @@
-﻿
-using MetroidPrimeRemasterModelDumper;
+﻿using MetroidPrimeRemasterModelDumper;
+
+string manifest = AppContext.BaseDirectory + "/ModelManifest.json";
+
+if (!File.Exists(manifest))
+{
+    Console.WriteLine("The model manifest does not exist. Please provide the ROMFS directory so ");
+    Console.WriteLine("that a model manifest can be created. Please do not move the ROMFS once the");
+    Console.WriteLine("manifest is created, as the paths to the paks will be saved for future use.");
+    string romDir = Console.ReadLine();
+
+    ModelManifester.ProcessModels(romDir);
+}
 
 foreach (var arg in args)
 {

--- a/MetroidPrimeRemasterModelDumper/Program.cs
+++ b/MetroidPrimeRemasterModelDumper/Program.cs
@@ -1,4 +1,5 @@
 ﻿using MetroidPrimeRemasterModelDumper;
+#nullable disable
 
 string manifest = AppContext.BaseDirectory + "/ModelManifest.json";
 
@@ -16,6 +17,22 @@ foreach (var arg in args)
 {
     if (arg.EndsWith(".pak"))
     {
-        BatchPakExtractor.ExtractModels(arg);
+        try
+        {
+            BatchPakExtractor.ExtractModels(arg);
+        }
+        catch (Exception e)
+        {
+
+            Console.WriteLine(e.ToString());
+
+            Console.Write("Press any key to continue");
+            Console.ReadKey();
+
+            throw;
+        }
+
+
+
     }
 }

--- a/MetroidPrimeRemasterModelDumper/Tools/BatchPakExtractor.cs
+++ b/MetroidPrimeRemasterModelDumper/Tools/BatchPakExtractor.cs
@@ -1,16 +1,31 @@
-﻿using DKCTF;
+﻿using AvaloniaToolbox.Core.IO;
+using DKCTF;
 using EvilWithin2Tool;
+using IONET.Collada.Core.Extensibility;
 using RetroStudioPlugin.Files.FileData;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#nullable disable
 
 namespace MetroidPrimeRemasterModelDumper
 {
+    
+
     public class BatchPakExtractor
     {
+        public static PAK currentPak;
+        public static string savedMode = "Empty";
+
+        //public static PAK DupeData;
+
         public static void ExtractModels(string pakFile)
         {
             var ctx = new AvaloniaToolbox.Core.FileContext()
@@ -23,22 +38,100 @@ namespace MetroidPrimeRemasterModelDumper
             PAK pak = new PAK() { FileInfo = ctx };
             pak.Load(ctx);
 
+            currentPak = pak;
+
+            string mode;
+
+            if(savedMode == "Empty")
+            {
+                Console.WriteLine("Please specify the mode to run in: ");
+                Console.WriteLine("");
+                Console.WriteLine("    0 = Only CMDL files");
+                Console.WriteLine("    1 = Only CHPR files");
+                Console.WriteLine("    2 = Only CMDL files All");
+                Console.WriteLine("    3 = Only CHPR files All");
+                Console.WriteLine("");
+
+                mode = Console.ReadLine();
+            }
+            else
+            {
+                mode = savedMode;
+            }
+
             foreach (var fileInfo in pak.files)
             {
-                if (fileInfo.AssetEntry.Type == "CHPR")
-                    ExtractCharacterProject(fileInfo.FileData, pak);
+                switch (mode)
+                {
+                    case "0":
+                        if (fileInfo.AssetEntry.Type == "CMDL")
+                            ExtractCMDL(fileInfo.FileData, fileInfo, pak);
+                        break;
+                    case "1":
+                        if (fileInfo.AssetEntry.Type == "CHPR")
+                            ExtractCharacterProjectNew(fileInfo.FileData, pak, fileInfo);
+                        break;
+                    case "2":
+                        if (fileInfo.AssetEntry.Type == "CMDL")
+                            ExtractCMDL(fileInfo.FileData, fileInfo, pak);
+                        savedMode = "2";
+                        break;
+                    case "3":
+                        if (fileInfo.AssetEntry.Type == "CHPR")
+                            ExtractCharacterProjectNew(fileInfo.FileData, pak, fileInfo);
+                        savedMode = "3";
+                        break;
+                }
             }
         }
 
-        static void ExtractCharacterProject(Stream stream, PAK pak)
+        static void ExtractCMDL(Stream stream, FileEntry Entry, PAK pak)
+        {
+            Console.WriteLine("Asset ID: " + Entry.AssetEntry.FileID.ToString());
+
+            var cmdl = new CMDL(Entry.FileData);
+            string modelName = Entry.AssetEntry.FileID.ToString();
+
+            //string modelName = fileEntry.AssetEntry.FileID.ToString();
+            string folder = Path.Combine(Path.GetFileNameWithoutExtension(pak.FileInfo.FilePath), "CMDL_" + modelName);
+
+            if (!Directory.Exists(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+
+            string path = Path.Combine(folder, modelName);
+            CMDLExporter.Export(cmdl, path);
+        }
+
+        static void ExtractSMDL(Stream stream, FileEntry Entry, PAK pak)
+        {
+            Console.WriteLine("Asset ID: " + Entry.AssetEntry.FileID.ToString());
+
+            var cmdl = new CMDL(Entry.FileData);
+            string modelName = Entry.AssetEntry.FileID.ToString();
+
+            //string modelName = fileEntry.AssetEntry.FileID.ToString();
+            string folder = Path.Combine(pak.FileInfo.FilePath + "working", "SMDL_" + modelName);
+
+            if (!Directory.Exists(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+
+            string path = Path.Combine(folder, modelName);
+            CMDLExporter.Export(cmdl, folder);
+        }
+
+        static void ExtractCharacterProject(Stream stream, PAK pak, FileEntry fileInfo)
         {
             CHPR chpr = new CHPR(stream);
 
-            // Load models
-            foreach (var file in pak.files)
+            foreach (var charInfo in chpr.CharacterInfos)
             {
-                foreach (var charInfo in chpr.CharacterInfos)
-                {         
+                // Load models
+                foreach (var file in pak.files)
+                {
                     // sub name
                     string folder = charInfo.NamePool.GetString(chpr.CharacterInfos[0].SubCharData.SubChars[0].Name);
                     // Add pak folder name onto it
@@ -47,6 +140,8 @@ namespace MetroidPrimeRemasterModelDumper
 
                     foreach (var model in charInfo.ModelNodes)
                     {
+                        //Console.WriteLine(model.ModelFileGuid.ToString());
+
                         if (file.FileName.Contains(model.ModelFileGuid.ToString()))
                         {
                             if (!Directory.Exists(folder))
@@ -62,5 +157,123 @@ namespace MetroidPrimeRemasterModelDumper
                 }
             }
         }
+
+        static void ExtractCharacterProjectNew(Stream stream, PAK pak, FileEntry fileInfo)
+        {
+            CHPR chpr = new CHPR(stream);
+
+            foreach (var charInfo in chpr.CharacterInfos)
+            {
+                /*
+                // sub name
+                string folder = charInfo.NamePool.GetString(chpr.CharacterInfos[0].SubCharData.SubChars[0].Name);
+
+                // Add pak folder name onto it
+                folder = Path.Combine(Path.GetFileNameWithoutExtension(pak.FileInfo.FilePath), folder,
+                    file.AssetEntry.FileID.ToString());
+                */
+
+                foreach (var model in charInfo.ModelNodes)
+                {
+                    try
+                    {
+                        FileEntry file = SearchForModel(model.ModelFileGuid.ToString());
+
+                        // sub name
+                        string folder = charInfo.NamePool.GetString(chpr.CharacterInfos[0].SubCharData.SubChars[0].Name);
+
+                        // Add pak folder name onto it
+                        folder = Path.Combine(Path.GetFileNameWithoutExtension(pak.FileInfo.FilePath), folder,
+                            file.AssetEntry.FileID.ToString());
+
+                        //Console.WriteLine(model.ModelFileGuid.ToString());
+
+                        if (!Directory.Exists(folder))
+                            Directory.CreateDirectory(folder);
+
+                        var cmdl = new CMDL(file.FileData);
+                        string modelName = charInfo.NamePool.GetString(model.Name);
+
+                        string path = Path.Combine(folder, modelName + ".gltf");
+                        CMDLExporter.Export(cmdl, path, chpr);
+                    }
+                    catch
+                    {
+                        break;
+                    }
+                    
+                }
+            }
+        }
+
+
+        public static FileEntry SearchForModel(string FileID)
+        {
+            foreach (var fileInfo in currentPak.files)
+            {
+                if (fileInfo.AssetEntry.FileID.ToString() == FileID)
+                {
+                    return fileInfo;
+                }
+            }
+
+            // If it reaches here, in theory, the material isn't in the pak.
+            // If this is the case, time to consult the material manifest!
+            Console.WriteLine(FileID + " isn't in this pak! Retro, Why?!?");
+
+            //System.IO.File.WriteAllText(AppContext.BaseDirectory + "/" + FileID + ".txt", FileID);
+
+            return LocateModel(FileID);
+        }
+
+
+        public static FileEntry LocateModel(string ModelName)
+        {
+            string ManifestContent = File.ReadAllText(@"ModelManifest.json");
+            MaterialManifestSerializableEntry[] manifestEntries = JsonSerializer.Deserialize<MaterialManifestSerializableEntry[]>(ManifestContent);
+            Console.WriteLine("Total manifest entries: " + manifestEntries.Count());
+
+            FileEntry TargetedFile = new FileEntry();
+
+            foreach (var entry in manifestEntries)
+            {
+                for (int c = 0; c < entry.SMDLFiles.Count(); c++)
+                {
+                    if (entry.SMDLFiles[c] == ModelName)
+                    {
+                        TargetedFile = FetchModel(entry.PakPath, ModelName);
+                        break;
+                    }
+                }
+            }
+
+            return TargetedFile;
+        }
+
+        public static FileEntry FetchModel(string pakFile, string ModelName)
+        {
+            FileEntry TargetedFile = new FileEntry();
+
+            var ctx = new AvaloniaToolbox.Core.FileContext()
+            {
+                FilePath = pakFile,
+                FileName = Path.GetFileName(pakFile),
+                Stream = File.OpenRead(pakFile),
+            };
+
+            PAK pak = new PAK() { FileInfo = ctx };
+            pak.Load(ctx);
+
+            foreach (var fileInfo in pak.files)
+            {
+                if (fileInfo.AssetEntry.FileID.ToString() == ModelName)
+                {
+                    TargetedFile = fileInfo;
+                    break;
+                }
+            }
+            return TargetedFile;
+        }
+
     }
 }

--- a/MetroidPrimeRemasterModelDumper/Tools/BatchPakExtractor.cs
+++ b/MetroidPrimeRemasterModelDumper/Tools/BatchPakExtractor.cs
@@ -1,30 +1,30 @@
 ﻿using AvaloniaToolbox.Core.IO;
 using DKCTF;
 using EvilWithin2Tool;
+using ImageLibrary;
+using ImageLibrary.PlatformSwizzle;
 using IONET.Collada.Core.Extensibility;
+using IONET.Collada.Core.Lighting;
 using RetroStudioPlugin.Files.FileData;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+//using static ImageLibrary.ImageDds;
 
 #nullable disable
 
 namespace MetroidPrimeRemasterModelDumper
 {
-    
-
     public class BatchPakExtractor
     {
         public static PAK currentPak;
         public static string savedMode = "Empty";
 
         //public static PAK DupeData;
+        public static bool saveLODs;
+        public static bool makeFolders = false;
 
         public static void ExtractModels(string pakFile)
         {
@@ -41,15 +41,23 @@ namespace MetroidPrimeRemasterModelDumper
             currentPak = pak;
 
             string mode;
+            
 
             if(savedMode == "Empty")
             {
                 Console.WriteLine("Please specify the mode to run in: ");
                 Console.WriteLine("");
-                Console.WriteLine("    0 = Only CMDL files");
-                Console.WriteLine("    1 = Only CHPR files");
-                Console.WriteLine("    2 = Only CMDL files All");
-                Console.WriteLine("    3 = Only CHPR files All");
+                Console.WriteLine("    0 = Dump CMDL files");
+                Console.WriteLine("    1 = Dump CHPR files");
+                Console.WriteLine("    2 = Dump WMDL files");
+                Console.WriteLine("    3 = Dump CMDL files with LODs");
+                Console.WriteLine("    4 = Dump CHPR files with LODs");
+                Console.WriteLine("    5 = Dump WMDL files with LODs");
+                Console.WriteLine("    6 = Dump TXTR files");
+                Console.WriteLine("    7 = Dump TXTR files with folders for array textures");
+                Console.WriteLine("");
+                Console.WriteLine("WARNING: The way secondary and tertiary UVs are stored is not");
+                Console.WriteLine("well understood. Some UV maps may be missing or inaccurate.");
                 Console.WriteLine("");
 
                 mode = Console.ReadLine();
@@ -61,27 +69,62 @@ namespace MetroidPrimeRemasterModelDumper
 
             foreach (var fileInfo in pak.files)
             {
-                switch (mode)
+                try
                 {
-                    case "0":
-                        if (fileInfo.AssetEntry.Type == "CMDL")
-                            ExtractCMDL(fileInfo.FileData, fileInfo, pak);
-                        break;
-                    case "1":
-                        if (fileInfo.AssetEntry.Type == "CHPR")
-                            ExtractCharacterProjectNew(fileInfo.FileData, pak, fileInfo);
-                        break;
-                    case "2":
-                        if (fileInfo.AssetEntry.Type == "CMDL")
-                            ExtractCMDL(fileInfo.FileData, fileInfo, pak);
-                        savedMode = "2";
-                        break;
-                    case "3":
-                        if (fileInfo.AssetEntry.Type == "CHPR")
-                            ExtractCharacterProjectNew(fileInfo.FileData, pak, fileInfo);
-                        savedMode = "3";
-                        break;
+                    switch (mode)
+                    {
+                        case "0":
+                            if (fileInfo.AssetEntry.Type == "CMDL")
+                                ExtractCMDL(fileInfo.FileData, fileInfo, pak);
+                            savedMode = "0";
+                            break;
+                        case "1":
+                            if (fileInfo.AssetEntry.Type == "CHPR")
+                                ExtractCharacterProjectNew(fileInfo.FileData, pak, fileInfo);
+                            savedMode = "1";
+                            break;
+                        case "2":
+                            if (fileInfo.AssetEntry.Type == "WMDL")
+                                ExtractCMDL(fileInfo.FileData, fileInfo, pak);
+                            savedMode = "2";
+                            break;
+                        case "3":
+                            saveLODs = true;
+                            if (fileInfo.AssetEntry.Type == "CMDL")
+                                ExtractCMDL(fileInfo.FileData, fileInfo, pak);
+                            savedMode = "3";
+                            break;
+                        case "4":
+                            saveLODs = true;
+                            if (fileInfo.AssetEntry.Type == "CHPR")
+                                ExtractCharacterProjectNew(fileInfo.FileData, pak, fileInfo);
+                            savedMode = "4";
+                            break;
+                        case "5":
+                            saveLODs = true;
+                            if (fileInfo.AssetEntry.Type == "WMDL")
+                                ExtractCMDL(fileInfo.FileData, fileInfo, pak);
+                            savedMode = "5";
+                            break;
+                        case "6":
+                            if (fileInfo.AssetEntry.Type == "TXTR")
+                                ExtractTXTR(fileInfo.FileData, fileInfo, pak);
+                            savedMode = "6";
+                            break;
+                        case "7":
+                            makeFolders = true;
+                            if (fileInfo.AssetEntry.Type == "TXTR")
+                                ExtractTXTR(fileInfo.FileData, fileInfo, pak);
+                            savedMode = "7";
+                            break;
+                    }
                 }
+                catch
+                {
+                    Console.WriteLine("Error with file " + fileInfo.AssetEntry.FileID.ToString());
+                    throw;
+                }
+                
             }
         }
 
@@ -101,61 +144,7 @@ namespace MetroidPrimeRemasterModelDumper
             }
 
             string path = Path.Combine(folder, modelName);
-            CMDLExporter.Export(cmdl, path);
-        }
-
-        static void ExtractSMDL(Stream stream, FileEntry Entry, PAK pak)
-        {
-            Console.WriteLine("Asset ID: " + Entry.AssetEntry.FileID.ToString());
-
-            var cmdl = new CMDL(Entry.FileData);
-            string modelName = Entry.AssetEntry.FileID.ToString();
-
-            //string modelName = fileEntry.AssetEntry.FileID.ToString();
-            string folder = Path.Combine(pak.FileInfo.FilePath + "working", "SMDL_" + modelName);
-
-            if (!Directory.Exists(folder))
-            {
-                Directory.CreateDirectory(folder);
-            }
-
-            string path = Path.Combine(folder, modelName);
-            CMDLExporter.Export(cmdl, folder);
-        }
-
-        static void ExtractCharacterProject(Stream stream, PAK pak, FileEntry fileInfo)
-        {
-            CHPR chpr = new CHPR(stream);
-
-            foreach (var charInfo in chpr.CharacterInfos)
-            {
-                // Load models
-                foreach (var file in pak.files)
-                {
-                    // sub name
-                    string folder = charInfo.NamePool.GetString(chpr.CharacterInfos[0].SubCharData.SubChars[0].Name);
-                    // Add pak folder name onto it
-                    folder = Path.Combine(Path.GetFileNameWithoutExtension(pak.FileInfo.FilePath), folder,
-                        file.AssetEntry.FileID.ToString());
-
-                    foreach (var model in charInfo.ModelNodes)
-                    {
-                        //Console.WriteLine(model.ModelFileGuid.ToString());
-
-                        if (file.FileName.Contains(model.ModelFileGuid.ToString()))
-                        {
-                            if (!Directory.Exists(folder))
-                                Directory.CreateDirectory(folder);
-
-                            var cmdl = new CMDL(file.FileData);
-                            string modelName = charInfo.NamePool.GetString(model.Name);
-
-                            string path = Path.Combine(folder, modelName + ".gltf");
-                            CMDLExporter.Export(cmdl, path, chpr);
-                        }
-                    }
-                }
-            }
+            CMDLExporter.Export(cmdl, path, null, saveLODs);
         }
 
         static void ExtractCharacterProjectNew(Stream stream, PAK pak, FileEntry fileInfo)
@@ -164,15 +153,6 @@ namespace MetroidPrimeRemasterModelDumper
 
             foreach (var charInfo in chpr.CharacterInfos)
             {
-                /*
-                // sub name
-                string folder = charInfo.NamePool.GetString(chpr.CharacterInfos[0].SubCharData.SubChars[0].Name);
-
-                // Add pak folder name onto it
-                folder = Path.Combine(Path.GetFileNameWithoutExtension(pak.FileInfo.FilePath), folder,
-                    file.AssetEntry.FileID.ToString());
-                */
-
                 foreach (var model in charInfo.ModelNodes)
                 {
                     try
@@ -195,7 +175,7 @@ namespace MetroidPrimeRemasterModelDumper
                         string modelName = charInfo.NamePool.GetString(model.Name);
 
                         string path = Path.Combine(folder, modelName + ".gltf");
-                        CMDLExporter.Export(cmdl, path, chpr);
+                        CMDLExporter.Export(cmdl, path, chpr, saveLODs);
                     }
                     catch
                     {
@@ -206,6 +186,117 @@ namespace MetroidPrimeRemasterModelDumper
             }
         }
 
+        static void ExtractTXTR(Stream stream, FileEntry Entry, PAK pak)
+        {
+            var txtr = new TXTR(Entry.FileData);
+            string textureName = Entry.AssetEntry.FileID.ToString();
+
+            Console.WriteLine(txtr.TextureHeader.Format);
+
+            GenericTextureBase genericTexture = new()
+            {
+                Name = textureName,
+                Width = txtr.TextureHeader.Width,
+                Height = txtr.TextureHeader.Height,
+                ImageFormat = new ImageFormat(TXTR.FormatList[txtr.TextureHeader.Format]),
+            };
+
+            string folder;
+            string path;
+
+            if (makeFolders && txtr.TextureHeader.Type >= 4)
+            {
+                folder = Path.Combine(Path.GetFileNameWithoutExtension(pak.FileInfo.FilePath));
+
+                if (!Directory.Exists(folder))
+                {
+                    Directory.CreateDirectory(folder);
+                }
+
+                folder += "/" + textureName;
+
+                if (!Directory.Exists(folder))
+                {
+                    Directory.CreateDirectory(folder);
+                }
+
+                path = Path.Combine(folder, $"{textureName}.txtr.png");
+            }
+            else
+            {
+                folder = Path.Combine(Path.GetFileNameWithoutExtension(pak.FileInfo.FilePath));
+
+                if (!Directory.Exists(folder))
+                {
+                    Directory.CreateDirectory(folder);
+                }
+                path = Path.Combine(folder, $"{textureName}.txtr.png");
+            }
+
+            try
+            {
+                ExportToPng(path, txtr);
+            }
+            catch
+            {
+                if (!File.Exists(AppContext.BaseDirectory + "/ErroredTextures.txt"))
+                {
+                    string brokenTex = textureName + "     Format: " + txtr.TextureHeader.Format;
+                    File.WriteAllText(AppContext.BaseDirectory + "/ErroredTextures.txt", brokenTex);
+                }
+                else
+                {
+                    string brokenTexCont = Environment.NewLine + textureName + "     Format: " + txtr.TextureHeader.Format;
+                    File.AppendAllText(AppContext.BaseDirectory + "/ErroredTextures.txt", brokenTexCont);
+                }
+                File.WriteAllBytes(Path.Combine(folder, $"{textureName}" + ".bin"), txtr.BufferData);
+            }
+        }
+
+        static void ExportToPng(string outputPath, TXTR txtr)
+        {
+            // Type 2 = 3D Texture. If it is 3D, use Depth. Otherwise, Depth is 1.
+            uint actualDepth = txtr.TextureHeader.Type == 2 ? txtr.TextureHeader.Depth : 1;
+            //byte[] linearData = TXTR.Deswizzle(txtr.TextureHeader, txtr.BufferData);
+
+            Console.WriteLine("Texture Size: " + txtr.TextureSize.ToString());
+
+            GenericTextureBase genericTexture = new GenericTextureBase();
+
+            genericTexture.Width = txtr.TextureHeader.Width;
+            genericTexture.Height = txtr.TextureHeader.Height;
+            genericTexture.Depth = actualDepth;
+            genericTexture.MipCount = (uint)txtr.MipSizes.Length;
+            genericTexture.ImageFormat = new ImageFormat(TXTR.FormatList[txtr.TextureHeader.Format]);
+            genericTexture.PlatformSwizzle = new PlatformSwizzleSwitch();
+            genericTexture.Data = txtr.BufferData;
+
+            if (txtr.TextureHeader.Type == 3)
+            {
+                genericTexture.ArrayCount = 6;
+            }
+
+            if (txtr.TextureHeader.Type >= 4)
+            {
+                Console.WriteLine("Found a 3D texture. Type " + txtr.TextureHeader.Type + ".");
+                genericTexture.ArrayCount = txtr.TextureHeader.Depth;
+            }
+
+            /*
+            GenericTextureBase genericTexture = new()
+            {
+                Width = txtr.TextureHeader.Width,
+                Height = txtr.TextureHeader.Height,
+                Depth = actualDepth,
+                MipCount = (uint)txtr.MipSizes.Length,
+                ImageFormat = new ImageFormat(TXTR.FormatList[txtr.TextureHeader.Format]),
+                PlatformSwizzle = new PlatformSwizzleSwitch(),
+                Data = txtr.BufferData,
+            };
+            */
+
+            genericTexture.Export(outputPath);
+        }
 
         public static FileEntry SearchForModel(string FileID)
         {
@@ -226,10 +317,9 @@ namespace MetroidPrimeRemasterModelDumper
             return LocateModel(FileID);
         }
 
-
         public static FileEntry LocateModel(string ModelName)
         {
-            string ManifestContent = File.ReadAllText(@"ModelManifest.json");
+            string ManifestContent = File.ReadAllText(AppContext.BaseDirectory + "/ModelManifest.json");
             MaterialManifestSerializableEntry[] manifestEntries = JsonSerializer.Deserialize<MaterialManifestSerializableEntry[]>(ManifestContent);
             Console.WriteLine("Total manifest entries: " + manifestEntries.Count());
 

--- a/MetroidPrimeRemasterModelDumper/Tools/CMDLExporter.cs
+++ b/MetroidPrimeRemasterModelDumper/Tools/CMDLExporter.cs
@@ -1,5 +1,4 @@
-﻿
-using AvaloniaToolbox.Core;
+﻿using AvaloniaToolbox.Core;
 using DKCTF;
 using IONET;
 using IONET.Collada.Core.Geometry;
@@ -23,7 +22,7 @@ namespace EvilWithin2Tool
 {
     public class CMDLExporter
     {
-        public static void Export(CMDL cmdl, string path, CHPR charProject = null)
+        public static void Export(CMDL cmdl, string path, CHPR charProject = null, bool saveLODs = false)
         {
             IOScene ioscene = new IOScene();
 
@@ -80,8 +79,19 @@ namespace EvilWithin2Tool
                 });
             }
 
+            List<CMDL.CMesh> ExportMeshes;
+
+            if (saveLODs)
+            {
+                ExportMeshes = cmdl.Meshes;
+            }
+            else
+            {
+                ExportMeshes = cmdl.GetHighestLODMeshes();
+            }
+
             int MatName = 0;
-            foreach (var mesh in cmdl.Meshes)
+            foreach (var mesh in ExportMeshes)
             {
                 var mat = cmdl.Materials[mesh.Header.MaterialIndex];
 
@@ -110,8 +120,14 @@ namespace EvilWithin2Tool
                     iomesh.Vertices.Add(iovertex);
 
                     iovertex.SetUV(vert.TexCoord0.X, vert.TexCoord0.Y, 0);
-                    iovertex.SetUV(vert.TexCoord1.X, vert.TexCoord1.Y, 1);
-                    iovertex.SetUV(vert.TexCoord2.X, vert.TexCoord2.Y, 2);
+                    if (mesh.hasTexCoord1)
+                    {
+                        iovertex.SetUV(vert.TexCoord1.X, vert.TexCoord1.Y, 1);
+                    }
+                    if (mesh.hasTexCoord2)
+                    {
+                        iovertex.SetUV(vert.TexCoord2.X, vert.TexCoord2.Y, 2);
+                    }
 
                     iovertex.SetColor(
                         vert.Color1.X,

--- a/MetroidPrimeRemasterModelDumper/Tools/CMDLExporter.cs
+++ b/MetroidPrimeRemasterModelDumper/Tools/CMDLExporter.cs
@@ -1,16 +1,23 @@
-﻿using AvaloniaToolbox.Core;
+﻿
+using AvaloniaToolbox.Core;
 using DKCTF;
 using IONET;
+using IONET.Collada.Core.Geometry;
+using IONET.Collada.Core.Scene;
+using IONET.Collada.Core.Transform;
 using IONET.Core;
 using IONET.Core.Model;
 using IONET.Core.Skeleton;
 using RetroStudioPlugin.Files.FileData;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
+
+#nullable disable
 
 namespace EvilWithin2Tool
 {
@@ -73,13 +80,14 @@ namespace EvilWithin2Tool
                 });
             }
 
-
+            int MatName = 0;
             foreach (var mesh in cmdl.Meshes)
             {
                 var mat = cmdl.Materials[mesh.Header.MaterialIndex];
 
                 IOMesh iomesh = new IOMesh();
                 iomesh.Name = $"Mesh{iomodel.Meshes.Count}_{mat.Name}";
+                //iomesh.Name = $"Mesh{iomodel.Meshes.Count}_LOD{mesh.parentLOD}";
                 iomodel.Meshes.Add(iomesh);
 
                 foreach (var vert in mesh.Vertices)
@@ -89,13 +97,13 @@ namespace EvilWithin2Tool
                         Position = new System.Numerics.Vector3(
                             vert.Position.X,
                             vert.Position.Y,
-                            vert.Position.Z), 
+                            vert.Position.Z),
                         Normal = new System.Numerics.Vector3(
                             vert.Normal.X,
                             vert.Normal.Y,
                             vert.Normal.Z),
                         Tangent = new System.Numerics.Vector3(
-                            vert.Tangent.X, 
+                            vert.Tangent.X,
                             vert.Tangent.Y,
                             vert.Tangent.Z),
                     };
@@ -106,10 +114,10 @@ namespace EvilWithin2Tool
                     iovertex.SetUV(vert.TexCoord2.X, vert.TexCoord2.Y, 2);
 
                     iovertex.SetColor(
-                        vert.Color.X,
-                        vert.Color.Y,
-                        vert.Color.Z,
-                        vert.Color.W, 0);
+                        vert.Color1.X,
+                        vert.Color1.Y,
+                        vert.Color1.Z,
+                        vert.Color1.W, 0);
 
                     for (int j = 0; j < 4; j++)
                     {
@@ -125,10 +133,6 @@ namespace EvilWithin2Tool
                             Weight = vert.BoneWeights[j],
                         });
                     }
-                    iovertex.SetColor(vert.Color.X,
-                                      vert.Color.Y,
-                                      vert.Color.Z,
-                                      vert.Color.W, 0);
 
                     iovertex.Envelope.NormalizeByteType();
                 }
@@ -136,7 +140,7 @@ namespace EvilWithin2Tool
                 IOPolygon iopoly = new IOPolygon();
                 iomesh.Polygons.Add(iopoly);
 
-                iopoly.MaterialName = mat.Name;
+                iopoly.MaterialName = "Material_" + MatName++;
 
                 iomesh.TransformVertices(Matrix4x4.Identity);
 
@@ -144,9 +148,79 @@ namespace EvilWithin2Tool
                     iopoly.Indicies.Add((int)mesh.Indices[i]);
             }
 
-            IOManager.ExportScene(ioscene, path, new ExportSettings()
+            string materialTXT = "Texture IDs: ";
+
+            List<CMDL.CMaterial> mats = new List<CMDL.CMaterial>();
+
+            if (cmdl.Materials.Count > 0)
+            {
+                foreach (var mat in cmdl.Materials)
+                {
+                    mats.Add(mat);
+                }
+            }
+
+            CMDL.CMaterial[] cleanMats = mats.Distinct().ToArray();
+
+            foreach (var mat in cleanMats)
+            {
+                materialTXT += (System.Environment.NewLine + "Material: " + mat.Name);
+                foreach (var texture in mat.Textures)
+                {
+                    materialTXT += (System.Environment.NewLine + "UV Map: " + texture.UsageInfo.Flags.ToString() + "     " + texture.FileID.ToString() );
+                }
+                
+                foreach (var scalar in mat.Scalars)
+                {
+                    materialTXT += (System.Environment.NewLine + "Scalar Type: " + scalar.Key + "     Value: " + scalar.Value.ToString());
+                }
+
+                foreach (var i in mat.Int)
+                {
+                    materialTXT += (System.Environment.NewLine + "Integer Type: " + i.Key + "     Value: " + i.Value.ToString());
+                }
+
+                foreach (var i4 in mat.Int4)
+                {
+                    materialTXT += (System.Environment.NewLine + "Integer 4 Type: " + i4.Key);
+                    materialTXT += (System.Environment.NewLine + i4.Value[0]);
+                    materialTXT += (System.Environment.NewLine + i4.Value[1]);
+                    materialTXT += (System.Environment.NewLine + i4.Value[2]);
+                    materialTXT += (System.Environment.NewLine + i4.Value[3]);
+                }
+
+                foreach (var matrix in mat.Matrices)
+                {
+                    materialTXT += (System.Environment.NewLine + "Matrix Type: " + matrix.Key);
+                    materialTXT += (System.Environment.NewLine + matrix.Value[0].ToString() + ", " + matrix.Value[1].ToString() + ", " + matrix.Value[2].ToString() + ", " + matrix.Value[3].ToString());
+                    materialTXT += (System.Environment.NewLine + matrix.Value[4].ToString() + ", " + matrix.Value[5].ToString() + ", " + matrix.Value[6].ToString() + ", " + matrix.Value[7].ToString());
+                    materialTXT += (System.Environment.NewLine + matrix.Value[8].ToString() + ", " + matrix.Value[9].ToString() + ", " + matrix.Value[10].ToString() + ", " + matrix.Value[11].ToString());
+                    materialTXT += (System.Environment.NewLine + matrix.Value[12].ToString() + ", " + matrix.Value[13].ToString() + ", " + matrix.Value[14].ToString() + ", " + matrix.Value[15].ToString());
+                }
+                
+                foreach (var color in mat.Colors)
+                {
+                    materialTXT += (System.Environment.NewLine + "Color Type: " + color.Key);
+                    materialTXT += (System.Environment.NewLine + "R: " + color.Value.R.ToString());
+                    materialTXT += (System.Environment.NewLine + "G: " + color.Value.G.ToString());
+                    materialTXT += (System.Environment.NewLine + "B: " + color.Value.B.ToString());
+                    materialTXT += (System.Environment.NewLine + "A: " + color.Value.A.ToString());
+                }
+                materialTXT += System.Environment.NewLine;
+            }
+
+            File.WriteAllText(path + ".txt", materialTXT);
+
+            IOManager.ExportScene(ioscene, path + ".gltf", new ExportSettings()
             {
             });
         }
+
+    }
+
+    class ModelLod
+    {
+        public BitArray Meshes;
+        public float? Distance;
     }
 }


### PR DESCRIPTION
The tool now requests the ROM directory on first use in order to create a model manifest. This allows the tool to document the path to any PAK, as well as the SMDLs contained within said packs. The purpose of this is to allow the tool to find models referenced by a CHPR that are in separate paks. The Elite Pirates specifically were susceptible to this.

A try block was added to PAK.cs for reading file entries, as it appears GuiSysMP1.pak contains several entries with duplicate names. The current method of processing PAKs is not compatible with duplicate entries, so this was added as a temporary safety check to avoid hitting an error.

A change was made to how secondary UV maps were handled. Apparently, the offsets for UVs only point to the general location of the UVs, rather than a specific UV itself. For each additional UV, the reader now moves by 4 bytes. This doesn't appear to be perfect, so it's been placed into a try block for now. However, it fixes UVs on several thousand models. In order for this to work, several features for Tropical Freeze had to be gutted.

Vertex colors have been implemented, revealing the blending source for complex materials. This was problematic on Thardus, the only rigged model to use complex materials.

The tool now also creates a TXT file for each model that contains information on every material it contains. This allows anyone to locate the desired textures for a model easily.